### PR TITLE
fix(Capstone): Property name in comment

### DIFF
--- a/src/capstone/Search.jsx
+++ b/src/capstone/Search.jsx
@@ -43,7 +43,7 @@ class Search extends Component {
          * ✏️ 
          * You need to invoke the `handleSearch` props passed by the parent
          * Pass the latest `stateTicker` state when you invoke that function
-         * this.props.handleSearch(this.state.stockTicker)
+         * this.props.onSearch(this.state.stockTicker)
          */
     }
 


### PR DESCRIPTION
- the capstone.js passes the 'this.handleSearch' function to the onSearch property of the Search component, however in the comments of the Search component the property is called handleSearch