### PR TITLE
defaulting props with defaultProps

### DIFF
--- a/src/setup/Home.js
+++ b/src/setup/Home.js
@@ -53,8 +53,8 @@ class Home extends Component {
                 <TutorialNavigation>
                     {
                         tutorialMetadata.map((data, index) => {
-                            return <TutorialLink>
-                                <Link key={data.id} to={data.route}>{data.displayName}</Link>
+                            return <TutorialLink key={data.id}>
+                                <Link to={data.route}>{data.displayName}</Link>
                             </TutorialLink>
                         })
                     }

--- a/src/setup/renderer/CodeBlock.js
+++ b/src/setup/renderer/CodeBlock.js
@@ -12,11 +12,14 @@ Lowlight.registerLanguage('html', xml);
 function CodeBlock (props){
     return (
         <Lowlight
-            language={props.language || 'js'}
-            value={props.value || ''}
+            language={props.language}
+            value={props.value}
             inline={props.inline}
         />
     )
 }
-
+CodeBlock.defaultProps = {
+    language: 'js',
+    value: ''
+}
 export default CodeBlock;


### PR DESCRIPTION
react component defaultProps allows you to specify what the default props will be in a component if those specific props aren't specified when the component is invoked.