### PR TITLE
Small typo in first example fixed

### DIFF
--- a/src/tutorial/05-State.md
+++ b/src/tutorial/05-State.md
@@ -7,7 +7,7 @@ Remember when we looked at different ways of creating React component in the fir
 Below is a simple component that has a state. 
 
 ```jsx
-class Component extends React.Compoent {
+class Component extends React.Component {
     constructor(props){
         super(props);
         this.state = {


### PR DESCRIPTION
Fixed spelling of 'React.Component' in code example .