### PR TITLE
Add way to auto-play the tutorial online with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,7 @@
+ports:
+- port: 3000
+  onOpen: open-preview
+tasks:
+- before: export DANGEROUSLY_DISABLE_HOST_CHECK=true
+  init: yarn install
+  command: yarn start

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ After this is complete, the application will be deployed on port `3000`. Open a 
 
 -----
 
+## Online Tutorial
+
+You can also run this tutorial in Gitpod, a free online dev environment for GitHub:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/tyroprogrammer/learn-react-app/blob/master/src/exercise/01-HelloWorld.js)
+
+-----
+
 ## Following the tutorial
 
 Tutorials on this application are fairly straightforward to follow. Each tutorial has one or more exercises. You'll see once you are in the tutorial.


### PR DESCRIPTION
Hi, thanks a lot for making a really cool React tutorial! 💯

I work on Gitpod.io, a service that provides free online development environments, and I thought you might be interested in giving developers an easy option to automatically run your tutorial online.

I've set up Gitpod to prepare workspaces with `yarn install` and start the server with `yarn start`. It will also automatically open the first tutorial file (`01-HelloWorld.js`) and show the running web app in a Preview.

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/1ece5e9a-8217-44e5-9e83-a30b086dd4ac)
<img width="1552" alt="screenshot 2019-02-04 at 15 11 38" src="https://user-images.githubusercontent.com/599268/52213960-c9f21d00-2890-11e9-8ba5-3a662195f5d2.png">
Please let me know what you think. 🙂 